### PR TITLE
Generate source map from esprima tokens

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,8 @@
 
 var loaderUtils = require('loader-utils');
 var SourceMap = require('source-map');
+var SourceMapGenerator = SourceMap.SourceMapGenerator;
+var esprima = require('esprima');
 
 var SourceNode = SourceMap.SourceNode;
 var SourceMapConsumer = SourceMap.SourceMapConsumer;
@@ -13,8 +15,31 @@ module.exports = function(source, map) {
         this.cacheable();
     }
 
-    if (map) {
-        var currentRequest = loaderUtils.getCurrentRequest(this);
+    var defaultOptions = { generateSourceMapFromTokens: false };
+    var loaderOptions = Object.assign(defaultOptions, loaderUtils.getOptions(this) || {});
+    var currentRequest = loaderUtils.getCurrentRequest(this);
+
+    if (loaderOptions.generateSourceMapFromTokens) {
+        var output = prefix + source;
+        var tokens = esprima.tokenize(output, { loc: true });
+        var generator = new SourceMapGenerator({ name: currentRequest });
+
+        generator.setSourceContent(currentRequest, source);
+
+        for (var i = 2; i < tokens.length; i++) {
+            var token = tokens[i];
+
+            generator.addMapping({
+                source: currentRequest,
+                original: { line: token.loc.start.line - 2, column: token.loc.start.column },
+                generated: { line: token.loc.start.line, column: token.loc.start.column }
+            });
+        }
+
+        this.callback(null, output, generator.toJSON());
+
+        return;
+    } else if (map) {
         var node = SourceNode.fromStringWithSourceMap(source, new SourceMapConsumer(map));
 
         node.prepend(prefix);

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "main": "index.js",
   "dependencies": {
-    "loader-utils": "0.2.x",
+    "loader-utils": "^1.1.0",
     "source-map": "0.5.x"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "main": "index.js",
   "dependencies": {
     "loader-utils": "^1.1.0",
+    "esprima": "^3.1.3",
     "source-map": "0.5.x"
   },
   "devDependencies": {

--- a/tasks/index.js
+++ b/tasks/index.js
@@ -48,7 +48,7 @@ exports.demo = function demo() {
                 {
                     test: /\.js$/,
                     loaders: [
-                        './index.js'
+                        './index.js?generateSourceMapFromTokens'
                     ]
                 }
             ]


### PR DESCRIPTION
Currently it can't generate source map without input source map.
So it can show wrong stack traces.

I added `generateSourceMapFromTokens` and it generate source map from tokens using esprima.

## How to test

### With v1.1.0

```
$ git checkout https://github.com/yuya-takeyama/strict-loader-test
$ yarn
$ yarn start
...
/Users/yuya/src/github.com/yuya-takeyama/strict-loader-test/foo.js:9
    throw new Error('Fail');
^
Error: Fail
    at bar (/Users/yuya/src/github.com/yuya-takeyama/strict-loader-test/foo.js:9:1)
    at foo (/Users/yuya/src/github.com/yuya-takeyama/strict-loader-test/foo.js:4:1)
    at Object.<anonymous> (/Users/yuya/src/github.com/yuya-takeyama/strict-loader-test/index.js:7:1)
...
error Command failed with exit code 1.
```

### With this patch

```
$ git checkout use-fork
$ yarn
$ yarn start
...
/Users/yuya/src/github.com/yuya-takeyama/strict-loader-test/foo.js:7
    throw new Error('Fail');
          ^
Error: Fail
    at bar (/Users/yuya/src/github.com/yuya-takeyama/strict-loader-test/foo.js:7:11)
    at foo (/Users/yuya/src/github.com/yuya-takeyama/strict-loader-test/foo.js:2:3)
    at Object.<anonymous> (/Users/yuya/src/github.com/yuya-takeyama/strict-loader-test/index.js:5:1)
...
error Command failed with exit code 1.
```